### PR TITLE
name changes to  K8s Service Manager for PCF

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -1,13 +1,15 @@
 ---
-title: Using Pivotal Bazaar for PCF
+title: Using Kubernetes Service Manager for PCF
 owner: ISM
 ---
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to use Pivotal Bazaar for PCF.
+This topic describes how to use Kubernetes Service Manager for PCF.
 
-##<a id='using'></a> Using Pivotal Bazaar for PCF
+##<a id='using'></a> Using Kubernetes Service Manager for PCF
+
+Kubernetes Service Manager for PCF utilizes both the Bazaar CLI and a generic broker.
 
 ###<a id='shared'></a> Shared Instances and Add-ons
 Shared instances and add-ons are installed directly into a PKS cluster.
@@ -37,12 +39,12 @@ bazaar chart install -d ./tmp -c (cluster name) -n (name of installation) -f (va
 ```
 
 Each service will likely need some service specific configuration, which is specified by the
-values yaml file. On a successful install run, Bazaar will output information about the service
+values yaml file. On a successful install run, Kubernetes Service Manager for PCF will output information about the service
 (how to get credentials, etc).
 
 
 ###<a id='dedicated'></a> Dedicated Instances
-Dedicated instances are provided through a broker installed via the Bazaar tile. When a
+Dedicated instances are provided through a broker installed via the Kubernetes Service Manager for PCF tile. When a
 [Pivotal Application Service (PAS)](https://pivotal.io/platform/pivotal-application-service)
 developer uses `cf create-service`, the broker creates a dedicated instance of
 the service in the backing cluster.
@@ -110,19 +112,19 @@ Re-package your helm chart
 helm package (your product)
 ```
 
-To add service offering to bazaar that can then be used by the developer to provision from cf marketplace, run
+To add service offering to Kubernetes Service Manager for PCF that can then be used by the developer to provision from cf marketplace, run
 
 ```bash
 bazaar -t (bazaar api) -u (username) -p (password) offer save ./tmp/(your product).tgz
 ```
 
-To list existing service offerings available in bazaar, run
+To list existing service offerings available in Kubernetes Service Manager for PCF, run
 
 ```bash
 bazaar -t (bazaar api) -u (username) -p (password) offer list ./tmp/(your product).tgz
 ```
 
-To delete any service offerings from bazaar, run
+To delete any service offerings from Kubernetes Service Manager for PCF, run
 
 ```bash
 bazaar -t (bazaar api) -u (username) -p (password) offer delete ./tmp/(your product).tgz
@@ -132,7 +134,7 @@ bazaar -t (bazaar api) -u (username) -p (password) offer delete ./tmp/(your prod
 
 For air-gapped environments that cannot reach out to common registries such as
 [Docker Hub](https://hub.docker.com/) and
-[Quay](https://quay.io/), or for images that aren't public, Bazaar's `download` command will also
+[Quay](https://quay.io/), or for images that aren't public, the Bazaar CLI's `download` command will also
 get the container images off of Pivotal Network. These images need to be loaded into a private registry. The `docker`
 CLI [can add images](https://docs.docker.com/engine/reference/commandline/load/). The Bazaar CLI does, however,
 include a command that can handle many use cases. To load an image into a private registry, run
@@ -162,7 +164,7 @@ In addition to defining plans, there are some other items things to keep in mind
 ### <a id='issue-debugging'></a> Advanced Debugging
 Advanced Debugging might require talking directly to the underlying Helm and Kubernetes:
 
-* [Tiller](https://docs.helm.sh/glossary/#tiller) is the service side component of helm. Bazaar installs
+* [Tiller](https://docs.helm.sh/glossary/#tiller) is the service side component of helm. Kubernetes Service Manager for PCF installs
 Tiller into a specific namespace, `kibosh`. To manual run Helm commands, log into the Kubernetes
 cluster and include the namespace flag to talk to Kibosh's helm `--tiller-namespace=kibosh`.
 * <span style="color: deeppink; font-weight: bold">todo: mTLS credentials - need tile to test</a>


### PR DESCRIPTION
submitting as a PR because I made selective changes to separate Kubernetes Service Manager for PCF and the Bazaar CLI, for initial release